### PR TITLE
Add input

### DIFF
--- a/input.lisp
+++ b/input.lisp
@@ -148,3 +148,43 @@
   (let ((array (make-array (file-length input)
 			   :element-type (stream-element-type input))))
     (make-input (subseq array 0 (read-sequence array input)))))
+
+;;;
+
+(defstruct (readline-stream (:include index))
+  (read-function (lambda () (read-line t nil))
+   :type function
+   :read-only t)
+  (string
+   ""
+   :type string))
+
+(defmethod make-input ((input readline-stream))
+  input)
+
+(defmethod input-element-type ((input readline-stream))
+  'character)
+
+(defmethod input-empty-p ((input readline-stream))
+  (loop
+    (if (<= (length (readline-stream-string input))
+	    (readline-stream-position input))
+	(let ((line (funcall (readline-stream-read-function input))))
+	  (if line
+	      (setf (readline-stream-string input)
+		    (concatenate 'string
+				 (readline-stream-string input)
+				 (string #\newline)
+				 line))
+	      (return t)))
+	(return nil))))
+
+(defmethod input-first ((input readline-stream))
+  (aref (readline-stream-string input)
+	(readline-stream-position input)))
+
+(defmethod input-rest ((input readline-stream))
+  (make-readline-stream
+   :read-function (readline-stream-read-function input)
+   :string (readline-stream-string input)
+   :position (1+ (readline-stream-position input))))

--- a/input.lisp
+++ b/input.lisp
@@ -151,13 +151,17 @@
 
 ;;;
 
-(defstruct (readline-stream (:include index))
+(defstruct (readline-stream (:include index)
+			    (:constructor make-readline-stream-internal))
   (read-function (lambda () (read-line t nil))
    :type function
    :read-only t)
   (string
    ""
    :type string))
+
+(defun make-readline-stream (read-function)
+  (make-readline-stream-internal :read-function read-function))
 
 (defmethod make-input ((input readline-stream))
   input)
@@ -184,7 +188,7 @@
 	(readline-stream-position input)))
 
 (defmethod input-rest ((input readline-stream))
-  (make-readline-stream
+  (make-readline-stream-internal
    :read-function (readline-stream-read-function input)
    :string (readline-stream-string input)
    :position (1+ (readline-stream-position input))))

--- a/packages.lisp
+++ b/packages.lisp
@@ -42,7 +42,8 @@ Manual](manual.html) for a general introduction.")
 	   :=handler-case
 	   :=restart-case
 	   :run
-	   :get-input-position))
+	   :get-input-position
+	   :make-readline-stream))
 
 (defpackage mpc.characters
   (:documentation


### PR DESCRIPTION
I want to use read-line from standard input.
for example 

```
* (in-package :mpc)

#<PACKAGE "MPC">
* (run (=list (mpc.characters:=skip-whitespace (=one-or-more (=satisfies 'alphanumericp)))
            (mpc.characters:=skip-whitespace (=one-or-more (=satisfies 'alphanumericp)))
            (mpc.characters:=skip-whitespace (=one-or-more (=satisfies 'alphanumericp))))
       (make-readline-stream :read-function (lambda () (read-line t nil)))))
this is 
example

((#\t #\h #\i #\s) (#\i #\s) (#\e #\x #\a #\m #\p #\l #\e))
```
